### PR TITLE
fix: nunjucks-resource-renderer typo (issue #19)

### DIFF
--- a/unthink-stack/package.json
+++ b/unthink-stack/package.json
@@ -95,7 +95,7 @@
     "jsonwebtoken": "^8.5.1",
     "mongodb": "^3.5.4",
     "nunjucks": "^3.2.0",
-    "nunjucks-reource-renderer": "git+https://github.com/epandco/nunjucks-resource-renderer#a9fe9d22ac47f7e178de53737004a936d7c9bacd",
+    "nunjucks-resource-renderer": "git+https://github.com/epandco/nunjucks-resource-renderer#a9fe9d22ac47f7e178de53737004a936d7c9bacd",
     "pino-pretty": "^3.6.0",
     "reflect-metadata": "^0.1.13",
     "resource-decorator": "git+https://github.com/epandco/resource-decorator#03f424a173b7376d52ed60126ac2da9e1387704f"

--- a/unthink-stack/src/server/server.ts
+++ b/unthink-stack/src/server/server.ts
@@ -8,7 +8,7 @@ import {defaultContainer} from './config/di-container';
 import { registerResource } from 'express-register-resource';
 import { ResourceType, registerDefaultRenderer } from 'resource-decorator';
 import { HelloWorldResource } from './resources/hello-world-resource';
-import { NunjucksResourceRenderer } from 'nunjucks-reource-renderer';
+import { NunjucksResourceRenderer } from 'nunjucks-resource-renderer';
 
 const app: express.Application = express();
 app.use(cookieParser());


### PR DESCRIPTION
Changing `nunjucks-reource-renderer` to `nunjucks-resource-renderer` in `package.json` and in the import statement in `server.ts`.

Closes #19 