### PR TITLE
Simplified the init command a little bit.

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -50,7 +50,7 @@ const command: GluegunCommand = {
     }
 
     if (force) {
-      const response = toolbox.prompt.confirm(
+      const response = await toolbox.prompt.confirm(
         'Are you sure you want to force initialization? (overwrites files in destination)',
         false
       );


### PR DESCRIPTION
Simplified the directory check before init is run opting to bail out if the path exists at all irrespective if it's empty. This seems reasonable.

A few other items tackled were:
- projectName now is expected to be a path not just a name so you can run the tool and place the project where ever by doing `unthink i path/to/the/project/`. It also doesn't assume that project starts in the current directory. 
- No need to us the `esnureDir` as the copy function creates the dir if it doesn't exist (at least seems to from my testing)
- The copy filter is more robust and simpler using regex to specify what gets excluded. This is largely to ensure if npm run build is executed in the unthink-stack dir that the build output doesn't make it in the initialized project.