### PR TITLE
Version page

### DIFF
--- a/unthink-stack/src/content/templates/version.html
+++ b/unthink-stack/src/content/templates/version.html
@@ -23,6 +23,6 @@
   </style>
 </head>
 <body>
-  <div class="version">{{ content.name }} {{ content.version }}</div>
+  <div class="version">{{ content.APP_NAME }} {{ APP_VERSION }}</div>
 </body>
 </html>

--- a/unthink-stack/src/content/templates/version.html
+++ b/unthink-stack/src/content/templates/version.html
@@ -23,6 +23,6 @@
   </style>
 </head>
 <body>
-  <div class="version">{{ content.APP_NAME }} {{ APP_VERSION }}</div>
+  <div class="version">{{ content.appName }} {{ APP_VERSION }}</div>
 </body>
 </html>

--- a/unthink-stack/src/content/templates/version.html
+++ b/unthink-stack/src/content/templates/version.html
@@ -7,8 +7,7 @@
   <style>
     body {
       margin: 2rem;
-      color: #333333;
-      font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif;
+      font-family: SFMono-Regular, Menlo, monospace;
       text-rendering: optimizeLegibility;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
@@ -16,8 +15,10 @@
     .version {
       display: inline-block;
       padding: 0.75rem 1.5rem;
-      background: #EEEEEE;
-      border-radius: 2rem;
+      font-size: 0.875rem;
+      color: #305580;
+      background: #EFF7FF;
+      border-radius: 0.25rem;
     }
   </style>
 </head>

--- a/unthink-stack/src/content/templates/version.html
+++ b/unthink-stack/src/content/templates/version.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <style>
+    body {
+      margin: 2rem;
+      color: #333333;
+      font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif;
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+    .version {
+      display: inline-block;
+      padding: 0.75rem 1.5rem;
+      background: #EEEEEE;
+      border-radius: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="version">{{ content.name }} {{ content.version }}</div>
+</body>
+</html>

--- a/unthink-stack/src/server/config/config.ts
+++ b/unthink-stack/src/server/config/config.ts
@@ -1,4 +1,5 @@
 import * as dotenv from 'dotenv';
+import * as fs from 'fs';
 
 dotenv.config();
 
@@ -23,3 +24,6 @@ export const nunjucksFatalErrorTemplate = getEnvironmentValue('NUNJUCKS_TEMPLATE
 export const nunjucksUnauthorizedTemplate = getEnvironmentValue('NUNJUCKS_TEMPLATE_UNAUTHORIZED');
 
 export const contentBasePath: string = getEnvironmentValue('CONTENT_BASE_PATH');
+
+export const appName: string = JSON.parse(fs.readFileSync('./package.json').toString()).name;
+export const appVersion: string = JSON.parse(fs.readFileSync('./package.json').toString()).version;

--- a/unthink-stack/src/server/config/config.ts
+++ b/unthink-stack/src/server/config/config.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs';
 
 dotenv.config();
 
+const packageJSON = JSON.parse(fs.readFileSync('./package.json').toString());
+
 function getEnvironmentValue(name: string): string {
   if (process.env[name]) {
     return process.env[name] as string;
@@ -25,5 +27,5 @@ export const nunjucksUnauthorizedTemplate = getEnvironmentValue('NUNJUCKS_TEMPLA
 
 export const contentBasePath: string = getEnvironmentValue('CONTENT_BASE_PATH');
 
-export const appName: string = JSON.parse(fs.readFileSync('./package.json').toString()).name;
-export const appVersion: string = JSON.parse(fs.readFileSync('./package.json').toString()).version;
+export const appName: string = packageJSON.name;
+export const appVersion: string = packageJSON.version;

--- a/unthink-stack/src/server/resources/version-resource.ts
+++ b/unthink-stack/src/server/resources/version-resource.ts
@@ -7,7 +7,7 @@ export class VersionResource extends ResourceBase {
 
   @template()
   async versionPage(): Promise<TemplateResponse | RedirectResponse> {
-    return new TemplateResponse('version.html', { 'APP_NAME': appName });
+    return new TemplateResponse('version.html', { 'appName': appName });
   }
 
 }

--- a/unthink-stack/src/server/resources/version-resource.ts
+++ b/unthink-stack/src/server/resources/version-resource.ts
@@ -1,14 +1,13 @@
-import * as fs from 'fs';
 import { resource, template, TemplateResponse, RedirectResponse } from 'resource-decorator';
 import { ResourceBase } from './resource-base';
+import { appName } from '../config/config';
 
 @resource({ basePath: '/unthink/version' })
 export class VersionResource extends ResourceBase {
 
   @template()
   async versionPage(): Promise<TemplateResponse | RedirectResponse> {
-    const { name, version } = JSON.parse(fs.readFileSync('./package.json').toString());
-    return new TemplateResponse('version.html', { name: name, version: version });
+    return new TemplateResponse('version.html', { 'APP_NAME': appName });
   }
 
 }

--- a/unthink-stack/src/server/resources/version-resource.ts
+++ b/unthink-stack/src/server/resources/version-resource.ts
@@ -1,0 +1,14 @@
+import * as fs from 'fs';
+import { resource, template, TemplateResponse, RedirectResponse } from 'resource-decorator';
+import { ResourceBase } from './resource-base';
+
+@resource({ basePath: '/unthink/version' })
+export class VersionResource extends ResourceBase {
+
+  @template()
+  async versionPage(): Promise<TemplateResponse | RedirectResponse> {
+    const { name, version } = JSON.parse(fs.readFileSync('./package.json').toString());
+    return new TemplateResponse('version.html', { name: name, version: version });
+  }
+
+}

--- a/unthink-stack/src/server/server.ts
+++ b/unthink-stack/src/server/server.ts
@@ -7,6 +7,7 @@ import * as config from './config/config';
 import {defaultContainer} from './config/di-container';
 import { registerResource } from 'express-register-resource';
 import { ResourceType, registerDefaultRenderer } from 'resource-decorator';
+import { VersionResource } from './resources/version-resource';
 import { HelloWorldResource } from './resources/hello-world-resource';
 import { NunjucksResourceRenderer } from 'nunjucks-resource-renderer';
 
@@ -31,6 +32,7 @@ const nunjucksResourceRenderer = new NunjucksResourceRenderer(
 registerDefaultRenderer(ResourceType.TEMPLATE, nunjucksResourceRenderer);
 
 // Register resources here
+registerResource(app, VersionResource, defaultContainer);
 registerResource(app, HelloWorldResource, defaultContainer);
 
 // For local development, the webpack dev server is used to serve up bundles

--- a/unthink-stack/src/server/server.ts
+++ b/unthink-stack/src/server/server.ts
@@ -14,14 +14,11 @@ import { NunjucksResourceRenderer } from 'nunjucks-resource-renderer';
 const app: express.Application = express();
 app.use(cookieParser());
 
-// open the package.json to get the version information
-const {version} = JSON.parse(fs.readFileSync('./package.json').toString());
-
 // Set up template rendering
 const nunjucksResourceRenderer = new NunjucksResourceRenderer(
   config.nunjucksBaseTemplatePath,
   {
-    'APP_VERSION': version,
+    'APP_VERSION': config.appVersion,
     'IS_PRODUCTION': config.isProduction
   },
   config.nunjucksNotFoundTemplate,


### PR DESCRIPTION
Adds a version page with project version pulled from `package.json`  (#12)

Created `version.html` template. I made this a standalone template that does not extend `base.html` since it's a simple page that does not need to inherit any styles or scripts.

Created `version-resource.ts` and registered the resource in `server.ts`. Do we want this to stay as its own resource? Or could we have a generic `app-resource`?

In `version-resource.ts` there is an `/unthink/version` route that returns the `version.html` template. I pull in the project name and version from `package.json` and pass it to the template. If we don't want to include the project name or any other info from `package.json`, it looks like `APP_VERSION` is already being passed to all templates, so I could just use that and simplify the resource a bit.