### PR TITLE
Webpack stats

### DIFF
--- a/unthink-stack/scripts/webpack.dev.js
+++ b/unthink-stack/scripts/webpack.dev.js
@@ -20,9 +20,7 @@ module.exports = merge(common, {
       cert: path.join(process.cwd(), 'certs', 'localhost.crt')
     },
     publicPath: '/public/js/',
-    stats: {
-      all: false
-    }
+    stats: 'errors-only'
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin()


### PR DESCRIPTION
Updated the stats field in the webpack config to use the `errors-only` preset. Addresses #17 and #18 

Sass errors in Riot files will now be logged like:

```
ERROR in ./entries/hello-world/hello-world.riot
[webpack] Module build failed (from /Users/luke.johnson/Desktop/cli-test/node_modules/@riotjs/webpack-loader/dist/riot-webpack-loader.cjs.js):
Error: Undefined variable.
  │
4 │       background-color: $background
  │                         ^^^^^^^^^^^
stdin 4:25  root stylesheet
  at Object._newRenderError (/Users/luke.johnson/Desktop/cli-test/node_modules/sass/sass.dart.js:13628:19)
  at Object._wrapException (/Users/luke.johnson/Desktop/cli-test/node_modules/sass/sass.dart.js:13474:16)
  at StaticClosure._renderSync (/Users/luke.johnson/Desktop/cli-test/node_modules/sass/sass.dart.js:13449:18)
  at Object.Primitives_applyFunction (/Users/luke.johnson/Desktop/cli-test/node_modules/sass/sass.dart.js:1064:30)
  at Object.Function_apply (/Users/luke.johnson/Desktop/cli-test/node_modules/sass/sass.dart.js:4895:16)
  at _callDartFunctionFast (/Users/luke.johnson/Desktop/cli-test/node_modules/sass/sass.dart.js:6577:16)
  at Object.renderSync (/Users/luke.johnson/Desktop/cli-test/node_modules/sass/sass.dart.js:6555:18)
  at /Users/luke.johnson/Desktop/cli-test/scripts/riot-preprocessors.js:55:22
  at transform (/Users/luke.johnson/Desktop/cli-test/node_modules/@riotjs/compiler/dist/index.js:146:30)
  at execute$1 (/Users/luke.johnson/Desktop/cli-test/node_modules/@riotjs/compiler/dist/index.js:245:10)
  @ ./entries/hello-world/hello-world.ts 2:0-44 4:12-22
｢wdm｣: Failed to compile.
```

Errors in .ts files will now be logged like:

```
ERROR in /Users/luke.johnson/Desktop/cli-test/src/client/entries/hello-world/hello-world.ts
./entries/hello-world/hello-world.ts
[tsl] ERROR in /Users/luke.johnson/Desktop/cli-test/src/client/entries/hello-world/hello-world.ts(6,5)
TS2322: Type '10' is not assignable to type 'string'.
｢wdm｣: Failed to compile.
```

Typescript errors in Riot files will be logged the same as before, with the addition of a stack trace.