### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,12 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="A cli for creating projects in the unthink stack.">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+  <link 
+    rel="stylesheet"
+    href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+    title="docsify-darklight-theme"
+    type="text/css"
+  />
 </head>
 <body>
   <div id="app"></div>
@@ -19,5 +24,9 @@
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs/components/prism-typescript.min.js"></script>
+  <script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+    type="text/javascript">
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Enabled dark and light mode with switch for docs using [docsify-darklight-theme](https://docsify-darklight-theme.boopathikumar.me/). Refer [docs](https://docsify-darklight-theme.boopathikumar.me/) for more customization 


# Before
![image](https://user-images.githubusercontent.com/10001746/82568525-94b03200-9b9c-11ea-951b-46d2eb8ede0b.png)

# After

## Light Mode

![image](https://user-images.githubusercontent.com/10001746/82568628-bb6e6880-9b9c-11ea-925c-8d6760cc5154.png)

## Dark Mode

![image](https://user-images.githubusercontent.com/10001746/82568588-aeea1000-9b9c-11ea-8c6d-a85697f3d93f.png)
