### PR TITLE
Updates project to use new middleware types in unthink-foundation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
   },
   "rules": {
     "semi": ["error", "always"],
-    "indent": ["error", 2],
+    "indent": ["error", 2, { "SwitchCase": 1 } ],
     "no-extra-semi": "error",
     "brace-style": ["error", "1tbs"],
     "quotes": ["error", "single"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@epandco/unthink",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epandco/unthink",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "A cli for creating projects in the unthink stack.",
   "types": "lib/types/types.d.ts",
   "unthink": {

--- a/unthink-stack/.eslintrc
+++ b/unthink-stack/.eslintrc
@@ -7,7 +7,7 @@
   },
   "rules": {
     "semi": ["error", "always"],
-    "indent": ["error", 2],
+    "indent": ["error", 2, { "SwitchCase": 1 } ],
     "no-extra-semi": "error",
     "brace-style": ["error", "1tbs"],
     "quotes": ["error", "single"],

--- a/unthink-stack/.eslintrc
+++ b/unthink-stack/.eslintrc
@@ -22,7 +22,9 @@
     "prefer-template": "error",
     "no-shadow-restricted-names": "error",
     "keyword-spacing": ["error", { "before": true, "after": true }],
-    "@typescript-eslint/explicit-function-return-type": "error",
+    "@typescript-eslint/explicit-function-return-type": ["error", {
+      "allowExpressions":  true
+    }],
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/array-type": ["error", { "default": "array" }]

--- a/unthink-stack/package-lock.json
+++ b/unthink-stack/package-lock.json
@@ -955,17 +955,17 @@
       "dev": true
     },
     "@epandco/unthink-foundation": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@epandco/unthink-foundation/-/unthink-foundation-1.0.0.tgz",
-      "integrity": "sha512-6Etl8O27brZZQcssvr8L+IZHE0PnmyNu+1agKzInUyiow7bE8m752KzqLcYiSc22a28CyXN17J711tz4uYtl8w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@epandco/unthink-foundation/-/unthink-foundation-2.1.0.tgz",
+      "integrity": "sha512-wWKyR+D9PA1m+jx90KZPHT7OU2z1SnA0P8GhK6jgJqg4T+LBCtM/PKsUzqHo6skOPDftVIm8DA3hiO8iyOdA2Q==",
       "requires": {
         "@types/pino": "^6.0.0"
       }
     },
     "@epandco/unthink-foundation-express": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@epandco/unthink-foundation-express/-/unthink-foundation-express-1.0.4.tgz",
-      "integrity": "sha512-VkInomBbK18C+ZqjeCEiAckJimMypKgbJCUd0OOVXMaTHJhSyWWuTKUdsgY9Nco3RBmlBxjerI8Gq0h0QKH0WQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@epandco/unthink-foundation-express/-/unthink-foundation-express-2.0.0.tgz",
+      "integrity": "sha512-a/V0FEnjYl+aOZImQzBvd1UYbCt6nn5yZ1INGsLNqGTv+8pm0X33zSsYtC44/uloT8iDlNgQfO/gzKa1syUVcg==",
       "requires": {
         "express-pino-logger": "^4.0.0"
       }
@@ -1301,9 +1301,9 @@
       "dev": true
     },
     "@types/pino": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.0.0.tgz",
-      "integrity": "sha512-V/ygB0a3bkuNMT+MgRd5wahC3dwgEtWyZG7eY2c9gJZZFoZbIQj8vo/h9h8A+iWJfXpzvm97XtydYvKuW2kt1Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.0.1.tgz",
+      "integrity": "sha512-GkOWuzB1vs6yhx8j9LxwE4LG6NANwpIjxg2q/Iev0cegOtoX8NGNI7PaJ3nTE75/vW5LANFXmuBOEWXbTGdxgQ==",
       "requires": {
         "@types/node": "*",
         "@types/pino-std-serializers": "*",

--- a/unthink-stack/package.json
+++ b/unthink-stack/package.json
@@ -80,8 +80,8 @@
     "shx": "^0.3.2"
   },
   "dependencies": {
-    "@epandco/unthink-foundation": "^1.0.0",
-    "@epandco/unthink-foundation-express": "^1.0.4",
+    "@epandco/unthink-foundation": "^2.1.0",
+    "@epandco/unthink-foundation-express": "^2.0.0",
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",

--- a/unthink-stack/package.json
+++ b/unthink-stack/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@epandco/unthink-foundation": "^2.1.0",
-    "@epandco/unthink-foundation-express": "^2.0.0",
+    "@epandco/unthink-foundation-express": "^2.0.1",
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",

--- a/unthink-stack/package.json
+++ b/unthink-stack/package.json
@@ -98,6 +98,6 @@
     "silent": true
   },
   "unthink": {
-    "version": "2.0.2"
+    "version": "3.0.0"
   }
 }

--- a/unthink-stack/src/server/nunjucks-renderer.ts
+++ b/unthink-stack/src/server/nunjucks-renderer.ts
@@ -28,18 +28,18 @@ export function renderTemplateWithContextAdded(result: Result, _ctx: RouteContex
     // Successful status codes should not make it to this function
     let template: string;
     switch (result.status) {
-    case 400:
-    case 500:
-      template = 'error.njk';
-      break;
-    case 401:
-      template = 'unauthorized.njk';
-      break;
-    case 404:
-      template = 'not-found.njk';
-      break;
-    default:
-      throw new Error(`A default template for status code ${result.status} is not supported in the render function`);
+      case 400:
+      case 500:
+        template = 'error.njk';
+        break;
+      case 401:
+        template = 'unauthorized.njk';
+        break;
+      case 404:
+        template = 'not-found.njk';
+        break;
+      default:
+        throw new Error(`A default template for status code ${result.status} is not supported in the render function`);
     }
 
     return render(template, result.value as object);

--- a/unthink-stack/src/server/nunjucks-renderer.ts
+++ b/unthink-stack/src/server/nunjucks-renderer.ts
@@ -1,5 +1,7 @@
 import * as config from './config/config';
 import { configure } from 'nunjucks';
+import { MiddlewareResult, RouteContext, ViewResult } from '@epandco/unthink-foundation';
+import { Result } from '@epandco/unthink-foundation/lib/foundation/result';
 
 const nunjucksEnvironment = configure(config.nunjucksBaseTemplatePath, { autoescape: true });
 
@@ -8,10 +10,40 @@ const nunjucksContext = {
   'IS_PRODUCTION': config.isProduction
 };
 
-export function renderTemplateWithContextAdded(template: string, value: unknown): string {
-  const valueCast = value as object | undefined;
-  const fullValue = { ...valueCast, ...nunjucksContext};
-  const result = nunjucksEnvironment.render(template as string, fullValue);
+function render(template: string, value: object | undefined): string {
+  const fullValue = { ...value, ...nunjucksContext};
+  const rendered = nunjucksEnvironment.render(template, fullValue);
 
-  return result;
+  return rendered;
+}
+
+export function renderTemplateWithContextAdded(result: Result, _ctx: RouteContext): string {
+  if (result instanceof ViewResult) {
+    return render(result.template as string, result.value as object);
+  }
+
+  if (result instanceof MiddlewareResult) {
+    // Only supporting error codes.
+    //
+    // Successful status codes should not make it to this function
+    let template: string;
+    switch (result.status) {
+    case 400:
+    case 500:
+      template = 'error.njk';
+      break;
+    case 401:
+      template = 'unauthorized.njk';
+      break;
+    case 404:
+      template = 'not-found.njk';
+      break;
+    default:
+      throw new Error(`A default template for status code ${result.status} is not supported in the render function`);
+    }
+
+    return render(template, result.value as object);
+  }
+
+  throw new Error('Result is not supported');
 }

--- a/unthink-stack/src/server/resources/hello-world-resource.ts
+++ b/unthink-stack/src/server/resources/hello-world-resource.ts
@@ -1,8 +1,7 @@
-import { expressResource } from '@epandco/unthink-foundation-express';
-import { data, DataResult, view } from '@epandco/unthink-foundation';
+import { unthinkResource, data, DataResult, view } from '@epandco/unthink-foundation';
 
 
-export default expressResource({
+export default unthinkResource({
   name: 'Root',
   routes: [
     view('/', 'hello-world.njk'),

--- a/unthink-stack/src/server/resources/missing-route-resource.ts
+++ b/unthink-stack/src/server/resources/missing-route-resource.ts
@@ -1,8 +1,7 @@
-import { expressResource } from '@epandco/unthink-foundation-express';
-import { data, DataResult, view } from '@epandco/unthink-foundation';
+import { unthinkResource, data, DataResult, view } from '@epandco/unthink-foundation';
 
 
-export default expressResource({
+export default unthinkResource({
   name: 'Not Found',
   routes: [
     data('*', {

--- a/unthink-stack/src/server/resources/version-resource.ts
+++ b/unthink-stack/src/server/resources/version-resource.ts
@@ -1,8 +1,7 @@
 import { appName } from '../config/config';
-import { expressResource } from '@epandco/unthink-foundation-express';
-import { view, ViewResult } from '@epandco/unthink-foundation';
+import { unthinkResource, view, ViewResult } from '@epandco/unthink-foundation';
 
-export default expressResource({
+export default unthinkResource({
   name: 'Version',
   basePath: '/unthink/version',
   routes: [


### PR DESCRIPTION
Middleware was overhauled unthink-foundation to provide an abstraction overt the underlying web framework. This will make the code more portable especially if we target serverless platforms like AWS Lambda/Azure functions. 