### PR TITLE
Fix init issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@epandco/unthink",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epandco/unthink",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A cli for creating projects in the unthink stack.",
   "types": "lib/types/types.d.ts",
   "unthink": {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -92,7 +92,7 @@ const command: GluegunCommand = {
     const stackGitIgnore = path.join(targetPath, '.stack-gitignore');
     const targetGitignore = path.join(targetPath, '.gitignore');
 
-    await fsExtra.move(stackGitIgnore, targetGitignore);
+    await fsExtra.move(stackGitIgnore, targetGitignore, { overwrite: true });
 
     await toolbox.package.loadAndUpdate(
       path.join(targetPath, 'package.json'),
@@ -114,12 +114,14 @@ const command: GluegunCommand = {
 
     // move existing readme to preserve it.
     await fsExtra.move(
-      path.join(targetPath, 'unthink-stack.md'),
+      path.join(targetPath, 'README.md'),
       path.join(targetPath, 'UNTHINK.md'),
       {
         overwrite: force
       }
     );
+
+    console.log('after move');
 
     // init .env file from the env.local file
 
@@ -132,8 +134,8 @@ const command: GluegunCommand = {
     );
 
     await toolbox.template.generate({
-      template: 'unthink-stack.md.ejs',
-      target: path.join(targetPath, 'unthink-stack.md'),
+      template: 'README.md.ejs',
+      target: path.join(targetPath, 'README.md'),
       props: { projectName },
     });
 


### PR DESCRIPTION
Resolves issues around initializing the project. 

The commit message mentions "overwriting" the `gitignore` if it exists - but this is only an issue when you run "npm link". The `gitignore` is present when you do npm link but not when installed via npm.

When installing via npm the README fixes are more relevant and were also needed.