### PR TITLE
correct the path for the version resource template.

### DIFF
--- a/unthink-stack/src/server/resources/version-resource.ts
+++ b/unthink-stack/src/server/resources/version-resource.ts
@@ -5,7 +5,7 @@ export default unthinkResource({
   name: 'Version',
   basePath: '/unthink/version',
   routes: [
-    view('/', async () => ViewResult.ok('version.html', {
+    view('/', async () => ViewResult.ok('version.njk', {
       value: { appName: appName}
     }))
   ]


### PR DESCRIPTION
Navingating to /unthink/version from a fresh project was throwing this error:

```Unexpected error: Error: template not found: version.html```

This change corrects this problem. 